### PR TITLE
fix: the extractcode tool uses strcpy to copy the in... in extractcode.c

### DIFF
--- a/tools/extractcode.c
+++ b/tools/extractcode.c
@@ -51,9 +51,10 @@ int main(int argc, char** argv) {
     char* ext = strrchr(filename, '.');
     if (!ext) return -1;
 
-    char* outfile = malloc(strlen(filename) + 2);
-    strcpy(outfile, filename);
-    strcpy(outfile + (ext - filename), ".code");
+    int baselen = ext - filename;
+    char* outfile = malloc(baselen + 6);
+    memcpy(outfile, filename, baselen);
+    memcpy(outfile + baselen, ".code", 6);
 
     FILE* fp = fopen(filename, "rb");
     if (!fp) return -1;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tools/extractcode.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tools/extractcode.c:55` |
| **CWE** | CWE-120 |

**Description**: The extractcode tool uses strcpy to copy the input filename into a heap-allocated buffer without bounds checking. If the ext pointer is NULL (no extension found in filename), the offset calculation (ext - filename) produces undefined behavior, and the subsequent strcpy writes '.code' at an invalid memory location. Additionally, if the filename is attacker-controlled, a crafted long filename can cause a heap buffer overflow.

## Changes
- `tools/extractcode.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
